### PR TITLE
Add ckanext-openapi, update ckanext-schemingdcat and minor fixes

### DIFF
--- a/playbook/inventories/development/host_vars/development_01.yml
+++ b/playbook/inventories/development/host_vars/development_01.yml
@@ -216,6 +216,9 @@ ckanext__schemingdcat_social_linkedin: "https://www.linkedin.com/company/ckanpro
 ckanext__schemingdcat__postgres__geojson_chars_limit: 1000
 ckanext__schemingdcat__postgres__geojson_tolerance: 0.001
 
+#### ckanext-openapi
+ckanext__openapi__endpoints: '[{"url":"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/examples/v3.0/api-with-examples.json","name":"sample","title":{"en":"OpenAPI sample 1","es":"Ejemplo de OpenAPI 1"},"description":{"en":"API with examples.","es":"API con ejemplos."}},{"url":"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/examples/v3.0/petstore.json","name":"petstore","title":{"en":"Petstore OpenAPI example","es":"Ejemplo OpenAPI Petstore"},"description":{"en":"This is a sample Pet Store Server based on the OpenAPI 3.0 specification.","es":"Este es un ejemplo de Servidor de Tienda de Mascotas basado en la especificación OpenAPI 3.0."}}]'
+
 ### Web Services config ############################################
 ### Enable all sites in ckan-ansible/playbook/roles/webserver/templates/sites-available/*.conf.j2
 sites_enabled:
@@ -265,6 +268,7 @@ ckanext_versions:
 # This is a dictionary of custom plugins to install. The key is the github user/repo and the value is the version to install.
 ckanext_custom_plugins:
   mjanez/ckanext-schemingdcat: v4.2.1
+  mjanez/ckanext-openapi: v1.0.0
 
 ### Solr Service #########################################
 solr_os_supported: 

--- a/playbook/inventories/development/host_vars/development_01.yml
+++ b/playbook/inventories/development/host_vars/development_01.yml
@@ -264,7 +264,7 @@ ckanext_versions:
 ### CKAN custom plugins #########################################
 # This is a dictionary of custom plugins to install. The key is the github user/repo and the value is the version to install.
 ckanext_custom_plugins:
-  mjanez/ckanext-schemingdcat: v4.1.0
+  mjanez/ckanext-schemingdcat: v4.2.1
 
 ### Solr Service #########################################
 solr_os_supported: 

--- a/playbook/inventories/os_vars/archlinux.yml
+++ b/playbook/inventories/os_vars/archlinux.yml
@@ -81,7 +81,7 @@ postgresql_deps_pkgs:
   - "postgresql-libs"
   - "python-psycopg2"
 postgresql_client_pkg: postgresql
-postgresqL_python3_psycopg2: python3-psycopg2
+postgresql_python3_psycopg: python3-psycopg2
 
 ### NGINX packages
 nginx_pkg: nginx

--- a/playbook/inventories/os_vars/centos-8.yml
+++ b/playbook/inventories/os_vars/centos-8.yml
@@ -92,7 +92,7 @@ postgresql_deps_pkgs:
   - postgresql-devel
   - "{{ python_pkg }}-psycopg2"
 postgresql_client_pkg: postgresql
-postgresqL_python3_psycopg2: python3-psycopg2
+postgresql_python3_psycopg: python3-psycopg2
 
 ### NGINX packages
 nginx_pkg: nginx

--- a/playbook/inventories/os_vars/centos-9.yml
+++ b/playbook/inventories/os_vars/centos-9.yml
@@ -92,7 +92,7 @@ postgresql_deps_pkgs:
   - postgresql-devel
   - "{{ python_pkg }}-psycopg2"
 postgresql_client_pkg: postgresql
-postgresqL_python3_psycopg2: python3-psycopg2
+postgresql_python3_psycopg: python3-psycopg2
 
 ### NGINX packages
 nginx_pkg: nginx

--- a/playbook/inventories/os_vars/debian-12.yml
+++ b/playbook/inventories/os_vars/debian-12.yml
@@ -88,7 +88,7 @@ postgresql_deps_pkgs:
   - "libpq-dev"
   - "python3-psycopg2"
 postgresql_client_pkg: postgresql
-postgresqL_python3_psycopg2: python3-psycopg2
+postgresql_python3_psycopg: python3-psycopg2
 
 ### NGINX packages
 nginx_pkg: nginx

--- a/playbook/inventories/os_vars/redhat-8.yml
+++ b/playbook/inventories/os_vars/redhat-8.yml
@@ -92,7 +92,7 @@ postgresql_deps_pkgs:
   - postgresql-devel
   - "{{ python_pkg }}-psycopg2"
 postgresql_client_pkg: postgresql
-postgresqL_python3_psycopg2: python3-psycopg2
+postgresql_python3_psycopg: python3-psycopg2
 
 ### NGINX packages
 nginx_pkg: nginx

--- a/playbook/inventories/os_vars/redhat-9.yml
+++ b/playbook/inventories/os_vars/redhat-9.yml
@@ -92,7 +92,7 @@ postgresql_deps_pkgs:
   - postgresql-devel
   - "{{ python_pkg }}-psycopg2"
 postgresql_client_pkg: postgresql
-postgresqL_python3_psycopg2: python3-psycopg2
+postgresql_python3_psycopg: python3-psycopg2
 
 ### NGINX packages
 nginx_pkg: nginx

--- a/playbook/inventories/production/host_vars/production_01.yml
+++ b/playbook/inventories/production/host_vars/production_01.yml
@@ -216,6 +216,9 @@ ckanext__schemingdcat_social_linkedin: "https://www.linkedin.com/company/ckanpro
 ckanext__schemingdcat__postgres__geojson_chars_limit: 1000
 ckanext__schemingdcat__postgres__geojson_tolerance: 0.001
 
+#### ckanext-openapi
+ckanext__openapi__endpoints: '[{"url":"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/examples/v3.0/api-with-examples.json","name":"sample","title":{"en":"OpenAPI sample 1","es":"Ejemplo de OpenAPI 1"},"description":{"en":"API with examples.","es":"API con ejemplos."}},{"url":"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/examples/v3.0/petstore.json","name":"petstore","title":{"en":"Petstore OpenAPI example","es":"Ejemplo OpenAPI Petstore"},"description":{"en":"This is a sample Pet Store Server based on the OpenAPI 3.0 specification.","es":"Este es un ejemplo de Servidor de Tienda de Mascotas basado en la especificación OpenAPI 3.0."}}]'
+
 ### Web Services config ############################################
 ### Enable all sites in ckan-ansible/playbook/roles/webserver/templates/sites-available/*.conf.j2
 sites_enabled:
@@ -265,6 +268,7 @@ ckanext_versions:
 # This is a dictionary of custom plugins to install. The key is the github user/repo and the value is the version to install.
 ckanext_custom_plugins:
   mjanez/ckanext-schemingdcat: v4.2.1
+  mjanez/ckanext-openapi: v1.0.0
 
 ### Solr Service #########################################
 solr_os_supported: 

--- a/playbook/inventories/production/host_vars/production_01.yml
+++ b/playbook/inventories/production/host_vars/production_01.yml
@@ -264,7 +264,7 @@ ckanext_versions:
 ### CKAN custom plugins #########################################
 # This is a dictionary of custom plugins to install. The key is the github user/repo and the value is the version to install.
 ckanext_custom_plugins:
-  mjanez/ckanext-schemingdcat: v4.1.0
+  mjanez/ckanext-schemingdcat: v4.2.1
 
 ### Solr Service #########################################
 solr_os_supported: 

--- a/playbook/inventories/staging/host_vars/staging_01.yml
+++ b/playbook/inventories/staging/host_vars/staging_01.yml
@@ -216,6 +216,9 @@ ckanext__schemingdcat_social_linkedin: "https://www.linkedin.com/company/ckanpro
 ckanext__schemingdcat__postgres__geojson_chars_limit: 1000
 ckanext__schemingdcat__postgres__geojson_tolerance: 0.001
 
+#### ckanext-openapi
+ckanext__openapi__endpoints: '[{"url":"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/examples/v3.0/api-with-examples.json","name":"sample","title":{"en":"OpenAPI sample 1","es":"Ejemplo de OpenAPI 1"},"description":{"en":"API with examples.","es":"API con ejemplos."}},{"url":"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/examples/v3.0/petstore.json","name":"petstore","title":{"en":"Petstore OpenAPI example","es":"Ejemplo OpenAPI Petstore"},"description":{"en":"This is a sample Pet Store Server based on the OpenAPI 3.0 specification.","es":"Este es un ejemplo de Servidor de Tienda de Mascotas basado en la especificación OpenAPI 3.0."}}]'
+
 ### Web Services config ############################################
 ### Enable all sites in ckan-ansible/playbook/roles/webserver/templates/sites-available/*.conf.j2
 sites_enabled:
@@ -265,6 +268,7 @@ ckanext_versions:
 # This is a dictionary of custom plugins to install. The key is the github user/repo and the value is the version to install.
 ckanext_custom_plugins:
   mjanez/ckanext-schemingdcat: v4.2.1
+  mjanez/ckanext-openapi: v1.0.0
 
 ### Solr Service #########################################
 solr_os_supported: 

--- a/playbook/inventories/staging/host_vars/staging_01.yml
+++ b/playbook/inventories/staging/host_vars/staging_01.yml
@@ -264,7 +264,7 @@ ckanext_versions:
 ### CKAN custom plugins #########################################
 # This is a dictionary of custom plugins to install. The key is the github user/repo and the value is the version to install.
 ckanext_custom_plugins:
-  mjanez/ckanext-schemingdcat: v4.1.0
+  mjanez/ckanext-schemingdcat: v4.2.1
 
 ### Solr Service #########################################
 solr_os_supported: 

--- a/playbook/roles/ckan/tasks/ckan_install_ckan_exts.yml
+++ b/playbook/roles/ckan/tasks/ckan_install_ckan_exts.yml
@@ -190,6 +190,21 @@
   become: true
   become_user: "{{ ckan_user }}"
 
+- name: Install ckan/ckanext-hierarchy {{ ckanext_versions.ckanext_hierarchy }}
+  vars:
+    virtualenv: "{{ ckan_virtualenv }}"
+  block:
+    - name: Install ckan/ckanext-hierarchy {{ ckanext_versions.ckanext_hierarchy }}
+      become: true
+      become_user: "{{ ckan_user }}"
+      pip:
+        name: git+https://github.com/ckan/ckanext-hierarchy.git@{{ ckanext_versions.ckanext_hierarchy }}#egg=ckanext-hierarchy
+        virtualenv: "{{ ckan_virtualenv }}"
+        extra_args: -e
+      register: result
+  become: true
+  become_user: "{{ ckan_user }}"
+
 - name: Installation of custom CKAN extensions for enhancements and theme improvements
   vars:
     virtualenv: "{{ ckan_virtualenv }}"

--- a/playbook/roles/ckan/tasks/ckan_test_conns.yml
+++ b/playbook/roles/ckan/tasks/ckan_test_conns.yml
@@ -20,10 +20,14 @@
     login_user: "{{ ckan_database.ckan_db_user }}"
     login_password: "{{ ckan_database.ckan_db_password }}"
     login_port: "{{ ckan_database.postgres_port }}"
-  register: db_conn
-  until: db_conn.is_available
+  register: main_db_conn
+  until: main_db_conn.is_available
   retries: 5
   delay: 10
+
+- name: Debug main_db_conn
+  debug:
+    var: main_db_conn
 
 - name: "Check datastore DB ({{ ckan_datastore.datastore_db }}) connection"
   postgresql_ping:
@@ -32,7 +36,11 @@
     login_user: "{{ ckan_database.ckan_db_user }}"
     login_password: "{{ ckan_database.ckan_db_password }}"
     login_port: "{{ ckan_datastore.datastore_port }}"
-  register: db_conn
-  until: db_conn.is_available
+  register: datastore_db_conn
+  until: datastore_db_conn.is_available
   retries: 5
   delay: 10
+
+- name: Debug datastore_db_conn
+  debug:
+    var: datastore_db_conn

--- a/playbook/roles/ckan/templates/ckan.ini.j2
+++ b/playbook/roles/ckan/templates/ckan.ini.j2
@@ -54,6 +54,8 @@ ckanext.schemingdcat.social_linkedin = {{ ckanext__schemingdcat_social_linkedin 
 ckanext.schemingdcat.postgres.geojson_chars_limit = {{ ckanext__schemingdcat__postgres__geojson_chars_limit }}
 ckanext.schemingdcat.postgres.geojson_tolerance = {{ ckanext__schemingdcat__postgres__geojson_tolerance }}
 
+### ckanext-openapi
+ckanext.openapi.endpoints = {{ ckanext__openapi__endpoints }}
 
 ### ckanext-spatial
 # Allow Solr local params

--- a/playbook/roles/database/tasks/database_config_psql_client.yml
+++ b/playbook/roles/database/tasks/database_config_psql_client.yml
@@ -21,19 +21,19 @@
 
 - name: Install python3-psycopg2 (RHEL/CentOS >= 8)
   dnf:
-    name: "{{ postgresql_python3_psycopg2['RedHat'] }}"
+    name: "{{ postgresql_python3_psycopg }}"
     state: present
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
 
 - name: Install python3-psycopg2 (Debian/Ubuntu)
   apt:
-    name: "{{ postgresql_python3_psycopg2['Debian'] }}"
+    name: "{{ postgresql_python3_psycopg }}"
     state: present
   when: ansible_os_family == "Debian"
 
 - name: Install python3-psycopg2 (Arch Linux)
   pacman:
-    name: "{{ postgresql_python3_psycopg2['Archlinux'] }}"
+    name: "{{ postgresql_python3_psycopg }}"
     state: present
   when: ansible_os_family == "Archlinux"
 

--- a/playbook/roles/database/tasks/database_config_psql_client.yml
+++ b/playbook/roles/database/tasks/database_config_psql_client.yml
@@ -19,6 +19,24 @@
     update_cache: true
   when: ansible_os_family == "Archlinux"
 
+- name: Install python3-psycopg2 (RHEL/CentOS >= 8)
+  dnf:
+    name: "{{ postgresql_python3_psycopg2['RedHat'] }}"
+    state: present
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
+
+- name: Install python3-psycopg2 (Debian/Ubuntu)
+  apt:
+    name: "{{ postgresql_python3_psycopg2['Debian'] }}"
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Install python3-psycopg2 (Arch Linux)
+  pacman:
+    name: "{{ postgresql_python3_psycopg2['Archlinux'] }}"
+    state: present
+  when: ansible_os_family == "Archlinux"
+
 - name: "Check if database {{ ckan_database.ckan_db }} exists"
   shell: |
     PGPASSWORD={{ ckan_database.ckan_db_password }} \

--- a/playbook/roles/database/tasks/database_install_psql.yml
+++ b/playbook/roles/database/tasks/database_install_psql.yml
@@ -21,19 +21,19 @@
 
 - name: Install python3-psycopg2 if python_pkg is not python3 (RHEL/CentOS)
   dnf:
-    name: "{{ postgresqL_python3_psycopg2 }}"
+    name: "{{ postgresql_python3_psycopg }}"
     state: present
   when: python_pkg != 'python3' and ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
 
 - name: Install python3-psycopg2 if python_pkg is not python3 (Debian/Ubuntu)
   apt:
-    name: "{{ postgresqL_python3_psycopg2 }}"
+    name: "{{ postgresql_python3_psycopg }}"
     state: present
   when: python_pkg != 'python3' and ansible_os_family == "Debian"
 
 - name: Install python3-psycopg2 if python_pkg is not python3 (Arch Linux)
   pacman:
-    name: "{{ postgresqL_python3_psycopg2 }}"
+    name: "{{ postgresql_python3_psycopg }}"
     state: present
   when: python_pkg != 'python3' and ansible_os_family == "Archlinux"
 


### PR DESCRIPTION
This pull request includes updates to the configuration files and installation scripts for various environments, focusing on adding support for the `ckanext-openapi` extension and correcting package names for PostgreSQL dependencies.

### Configuration Updates:
* Added `ckanext-openapi` endpoints configuration for development, production, and staging environments (`playbook/inventories/development/host_vars/development_01.yml`, `playbook/inventories/production/host_vars/production_01.yml`, `playbook/inventories/staging/host_vars/staging_01.yml`). [[1]](diffhunk://#diff-93d5f144118bf1f97755dc1868728db26095eb376fed00612d233671ccc29c1eR219-R221) [[2]](diffhunk://#diff-a7eb3e2ecb2f2453bdc69ef2d6cfd08d15efdc42b6187e5774f7a2f153ce0f26R219-R221) [[3]](diffhunk://#diff-da3dd7ec47909fa47bc2cca51748f8f92ce3194f3dcfcf26135bba56d1b9164cR219-R221)
* Updated custom plugins to include `ckanext-openapi` and upgraded `ckanext-schemingdcat` to version `v4.2.1` in development, production, and staging environments (`playbook/inventories/development/host_vars/development_01.yml`, `playbook/inventories/production/host_vars/production_01.yml`, `playbook/inventories/staging/host_vars/staging_01.yml`). [[1]](diffhunk://#diff-93d5f144118bf1f97755dc1868728db26095eb376fed00612d233671ccc29c1eL267-R271) [[2]](diffhunk://#diff-a7eb3e2ecb2f2453bdc69ef2d6cfd08d15efdc42b6187e5774f7a2f153ce0f26L267-R271) [[3]](diffhunk://#diff-da3dd7ec47909fa47bc2cca51748f8f92ce3194f3dcfcf26135bba56d1b9164cL267-R271)
* Added `ckanext-openapi` endpoints configuration to the `ckan.ini` template (`playbook/roles/ckan/templates/ckan.ini.j2`).

### Dependency Updates:
* Corrected the package name for `python3-psycopg2` in various OS-specific configuration files (`playbook/inventories/os_vars/archlinux.yml`, `playbook/inventories/os_vars/centos-8.yml`, `playbook/inventories/os_vars/centos-9.yml`, `playbook/inventories/os_vars/debian-12.yml`, `playbook/inventories/os_vars/redhat-8.yml`, `playbook/inventories/os_vars/redhat-9.yml`). [[1]](diffhunk://#diff-ecdf59826872e966f891b6e077c5b0bf01f509c5126483ce82d58fb945bbc10bL84-R84) [[2]](diffhunk://#diff-44fa7db66294fa2f369756a3efe87ce03983d9c62115eb090c61baaf377e4ca8L95-R95) [[3]](diffhunk://#diff-284e2812c75d7bc9fc7e819dbefb7cb5ab565fd6444849381ed7b4b32a84a304L95-R95) [[4]](diffhunk://#diff-d389ecc3ed132be878d4161fdf0819524a94960287530f7db82431d3b212af7fL91-R91) [[5]](diffhunk://#diff-5a2be94670f43594a6faaf5fc7d8f984a86049287d279ac93f20724e962b09d8L95-R95) [[6]](diffhunk://#diff-8b9a6a86b603f178d025b6fb7d0f409464c5b80bb3ac1ff9e5718a390be21d85L95-R95)
* Updated installation tasks to ensure `python3-psycopg2` is installed correctly across different OS families (`playbook/roles/database/tasks/database_config_psql_client.yml`, `playbook/roles/database/tasks/database_install_psql.yml`). [[1]](diffhunk://#diff-21980921febdfbe6f79bf3ab71c786af054ed22bfd9a57840377ee85519d1612R22-R39) [[2]](diffhunk://#diff-061767e0b682345e8ac18b56681fed4c3221457e8940af1e10464f20d202b57fL24-R36)

### Additional Changes:
* Added installation task for `ckanext-hierarchy` extension (`playbook/roles/ckan/tasks/ckan_install_ckan_exts.yml`).
* Improved database connection test tasks by renaming variables and adding debug information (`playbook/roles/ckan/tasks/ckan_test_conns.yml`).