### PR TITLE
Refactor resource and image size configurations to use template vars

### DIFF
--- a/playbook/roles/ckan/templates/ckan.ini.j2
+++ b/playbook/roles/ckan/templates/ckan.ini.j2
@@ -74,6 +74,7 @@ ckanext.schemingdcat.social_linkedin = {{ ckanext__schemingdcat_social_linkedin 
 ckanext.schemingdcat.postgres.geojson_chars_limit = {{ ckanext__schemingdcat__postgres__geojson_chars_limit }}
 ckanext.schemingdcat.postgres.geojson_tolerance = {{ ckanext__schemingdcat__postgres__geojson_tolerance }}
 ckanext.schemingdcat.api.private_fields = {{ ckanext__schemingdcat__api__private_fields }}
+ckanext.schemingdcat.csw.ssl_verify = {{ ckanext__schemingdcat__csw__ssl_verify }}
 
 ### ckanext-openapi
 ckanext.openapi.endpoints = {{ ckanext__openapi__endpoints }}

--- a/playbook/roles/ckan/templates/ckan.ini.j2
+++ b/playbook/roles/ckan/templates/ckan.ini.j2
@@ -302,8 +302,8 @@ ckan.admin_tabs = {}
 
 ## Storage Settings ############################################################
 ckan.storage_path = {{ ckan_storage_dir}}
-ckan.max_resource_size = 10
-ckan.max_image_size = 2
+ckan.max_resource_size = {{ ckan__max_resource_size }}
+ckan.max_image_size = {{ ckan__max_image_size }}
 
 ## Uploader Settings ###########################################################
 ckan.upload.user.types = image


### PR DESCRIPTION
This pull request includes updates to the `ckan.ini.j2` configuration file to improve flexibility and security settings. The most important changes involve parameterizing certain configuration values and adding a new SSL verification setting.

Configuration updates:

* [`playbook/roles/ckan/templates/ckan.ini.j2`](diffhunk://#diff-23a2a036020fa39c852ad155065e3bfd16af2b03d592714428141aaadcf9a79dR77): Added a new configuration parameter `ckanext.schemingdcat.csw.ssl_verify` to enable SSL verification for CSW endpoints.
* [`playbook/roles/ckan/templates/ckan.ini.j2`](diffhunk://#diff-23a2a036020fa39c852ad155065e3bfd16af2b03d592714428141aaadcf9a79dL304-R306): Parameterized `ckan.max_resource_size` and `ckan.max_image_size` settings to allow for dynamic configuration.